### PR TITLE
Allow config options to be specified instead of being read from file

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,26 @@ ResolutionMapBuilder.prototype = Object.create(Plugin.prototype);
 ResolutionMapBuilder.prototype.constructor = ResolutionMapBuilder;
 
 ResolutionMapBuilder.prototype.build = function() {
+  // Attempt to read config file
   let configPath = path.join(this.inputPaths[1], this.options.configPath);
-  let configContents = fs.readFileSync(configPath, { encoding: 'utf8' });
-  let config = JSON.parse(configContents);
+  let config;
+  if (fs.existsSync(configPath)) {
+    let configContents = fs.readFileSync(configPath, { encoding: 'utf8' });
+    config = JSON.parse(configContents);
+  } else {
+    config = {};
+  }
 
-  let modulePrefix = config.modulePrefix;
-  let moduleConfig = getModuleConfig(config);
+  let moduleConfig = getModuleConfig(config.moduleConfiguration || this.options.defaultModuleConfiguration);
+  if (!moduleConfig) {
+    throw new Error(`The module configuration could not be found. Please add a config file to '${configPath}' and export an object with a 'moduleConfiguration' member.`);
+  }
+
+  let modulePrefix = config.modulePrefix || this.options.modulePrefix;
+  if (!modulePrefix) {
+    throw new Error(`The module prefix could not be found. Add a config file to '${configPath}' and export an object with a 'modulePrefix' member.`);
+  }
+  
   let modulePaths = walkSync(this.inputPaths[0]);
   let mappedPaths = [];
   let moduleImports = [];

--- a/lib/get-module-config.js
+++ b/lib/get-module-config.js
@@ -1,11 +1,10 @@
 'use strict';
 
-module.exports = function(config) {
-  let moduleConfig = config.moduleConfiguration;
-
+module.exports = function(json) {
+  let { collections, types } = json;
+  let moduleConfig = { collections, types };
   let collectionMap = {};
   let collectionPaths = [];
-  let collections = moduleConfig.collections;
   let collectionNames = Object.keys(collections);
   collectionNames.forEach(function(collectionName) {
     var collection = collections[collectionName];

--- a/test/get-module-config-test.js
+++ b/test/get-module-config-test.js
@@ -25,14 +25,12 @@ describe('get-module-config', function() {
         types: ['service']
       }
     };
-    const config = {
-      moduleConfiguration: {
-        types,
-        collections
-      }
+    const resolverConfig = {
+      types,
+      collections
     };
 
-    let moduleConfig = getModuleConfig(config);
+    let moduleConfig = getModuleConfig(resolverConfig);
 
     assert.ok(moduleConfig, 'moduleConfig returned');
     assert.deepEqual(moduleConfig.types, types, 'types are returned unmodified');

--- a/test/get-module-specifier-test.js
+++ b/test/get-module-specifier-test.js
@@ -39,18 +39,16 @@ describe('get-module-specifier', function() {
       unresolvable: true
     }
   };
-  const config = {
-    moduleConfiguration: {
-      types,
-      collections
-    }
+  const resolverConfig = {
+    types,
+    collections
   };
   const modulePrefix = 'my-app';
 
   let moduleConfig;
 
   beforeEach(function() {
-    moduleConfig = getModuleConfig(config);
+    moduleConfig = getModuleConfig(resolverConfig);
   });
 
   it('identifies named modules in the root of a collection as the default type for that collection', function() {

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -6,10 +6,63 @@ const path = require('path');
 const assert = require('assert');
 
 describe('resolution-map-builder', function() {
-  it('logs specifiers if requested', function() {
+  it('can read a config file, parse modules, and log specifiers (if requested)', function() {
     let src = path.join(process.cwd(), 'test', 'fixtures', 'src');
     let config = path.join(process.cwd(), 'test', 'fixtures', 'config');
     let options = { configPath: 'environment.json', logSpecifiers: true };
+
+    let mapBuilder = new ResolutionMapBuilder(src, config, options);
+
+    return build(mapBuilder)
+      .then(result => {
+        assert.deepEqual(
+          mapBuilder.specifiers.sort(), 
+          [
+            'component:/my-app/components/my-app',
+            'template:/my-app/components/my-app',
+
+            'component:/my-app/components/text-editor',
+            'template:/my-app/components/text-editor',
+            
+            'component:/my-app/components/my-app/page-banner',
+            'template:/my-app/components/my-app/page-banner',
+            'component:/my-app/components/my-app/page-banner/titleize'
+          ].sort()
+        );
+      });
+  });
+
+  it('can use config options if no config file exists', function() {
+    let src = path.join(process.cwd(), 'test', 'fixtures', 'src');
+    let config = path.join(process.cwd(), 'test', 'fixtures', 'config');
+    let options = {
+      modulePrefix: 'my-app',
+      defaultModuleConfiguration: {
+        "types": {
+          "application": { "definitiveCollection": "main" },
+          "component": { "definitiveCollection": "components" },
+          "renderer": { "definitiveCollection": "main" },
+          "template": { "definitiveCollection": "components" },
+          "util": { "definitiveCollection": "utils" }
+        },
+        "collections": {
+          "main": {
+            "types": ["application", "renderer"]
+          },
+          "components": {
+            "group": "ui",
+            "types": ["component", "template"],
+            "defaultType": "component",
+            "privateCollections": "utils"
+          },
+          "utils": {
+            "unresolvable": true
+          }
+        }
+      },
+      configPath: 'DOES_NOT_EXIST.json', 
+      logSpecifiers: true 
+    };
 
     let mapBuilder = new ResolutionMapBuilder(src, config, options);
 


### PR DESCRIPTION
Adds support for the following options for this plugin:
* `modulePrefix` - this module prefix will be used if one can't be read from the config file
* `defaultModuleConfiguration` - this module config will be used if one can't be read from the config file