### PR TITLE
Allow defaultModulePrefix option instead of modulePrefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ ResolutionMapBuilder.prototype.build = function() {
     throw new Error(`The module configuration could not be found. Please add a config file to '${configPath}' and export an object with a 'moduleConfiguration' member.`);
   }
 
-  let modulePrefix = config.modulePrefix || this.options.modulePrefix;
+  let modulePrefix = config.modulePrefix || this.options.defaultModulePrefix;
   if (!modulePrefix) {
     throw new Error(`The module prefix could not be found. Add a config file to '${configPath}' and export an object with a 'modulePrefix' member.`);
   }

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -36,7 +36,7 @@ describe('resolution-map-builder', function() {
     let src = path.join(process.cwd(), 'test', 'fixtures', 'src');
     let config = path.join(process.cwd(), 'test', 'fixtures', 'config');
     let options = {
-      modulePrefix: 'my-app',
+      defaultModulePrefix: 'my-app',
       defaultModuleConfiguration: {
         "types": {
           "application": { "definitiveCollection": "main" },


### PR DESCRIPTION
Need to be clear that this is a fallback in case the modulePrefix 
can’t be read from the config file.