### PR TITLE
Ignore `.md` and `.html` files through heirarchy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const walkSync = require('walk-sync');
 const getModuleConfig = require('./lib/get-module-config');
 const getModuleSpecifier = require('./lib/get-module-specifier');
 
+const IGNORED_EXTENSIONS = ['', '.md', '.html'];
+
 function ResolutionMapBuilder(src, config, options) {
   options = options || {};
   Plugin.call(this, [src, config], {
@@ -46,13 +48,17 @@ ResolutionMapBuilder.prototype.build = function() {
   let mapContents = [];
 
   modulePaths.forEach(function(modulePath) {
-    if (modulePath.indexOf('.') > -1) {
-      let name = modulePath.substring(0, modulePath.lastIndexOf('.'));
+    let pathParts = path.parse(modulePath);
 
-      // filter out index module
-      if (name !== 'index' && name !== 'main') {
-        mappedPaths.push(modulePath);
-      }
+    if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1) {
+      return;
+    }
+
+    let name = pathParts.dir + '/' + pathParts.name;
+
+    // filter out index module
+    if (name !== 'index' && name !== 'main') {
+      mappedPaths.push(modulePath);
     }
   });
 

--- a/test/fixtures/src/ui/components/my-app/README.md
+++ b/test/fixtures/src/ui/components/my-app/README.md
@@ -1,0 +1,1 @@
+## My-App Component

--- a/test/fixtures/src/ui/index.html
+++ b/test/fixtures/src/ui/index.html
@@ -1,0 +1,4 @@
+<html>
+    <head></head>
+    <body></body>
+</html>


### PR DESCRIPTION
As mentioned [here](https://github.com/emberjs/rfcs/blob/master/text/0143-module-unification.md#non-resolved-files):

> The rules above apply to modules that are resolved, namely *.js
> and *.hbs files. Other files that are used for documenting code,
> such as *.md and *.html files, can be freely co-located in any
> directories.

Prior to these changes, adding a `.md` file or `.html` file to your
`src/` directory resulted in the following error:

```
 Error: The type of module 'ui/README' could not be identified
```