### PR TITLE
Force posix style paths to avoid issues with backslashes on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ ResolutionMapBuilder.prototype.constructor = ResolutionMapBuilder;
 
 ResolutionMapBuilder.prototype.build = function() {
   // Attempt to read config file
-  let configPath = path.join(this.inputPaths[1], this.options.configPath);
+  let configPath = path.posix.join(this.inputPaths[1], this.options.configPath);
   let config;
   if (fs.existsSync(configPath)) {
     let configContents = fs.readFileSync(configPath, { encoding: 'utf8' });
@@ -50,7 +50,7 @@ ResolutionMapBuilder.prototype.build = function() {
   }
 
   let baseDir = this.options.baseDir || '';
-  let modulePath = path.join(this.inputPaths[0], baseDir);
+  let modulePath = path.posix.join(this.inputPaths[0], baseDir);
   let modulePaths = walkSync(modulePath);
   let mappedPaths = [];
   let moduleImports = [];
@@ -63,7 +63,7 @@ ResolutionMapBuilder.prototype.build = function() {
       return;
     }
 
-    let name = path.join(pathParts.dir, pathParts.name);
+    let name = path.posix.join(pathParts.dir, pathParts.name);
 
     // filter out index module
     if (name !== 'index' && name !== 'main') {
@@ -83,7 +83,7 @@ ResolutionMapBuilder.prototype.build = function() {
     // Only process non-null specifiers returned.
     // Specifiers may be null in the case of an unresolvable collection (e.g. utils)
     if (specifier) {
-      let moduleImportPath = path.join('..', baseDir, module);
+      let moduleImportPath = path.posix.join('..', baseDir, module);
       let moduleVar = '__' + module.replace(/\//g, '__').replace(/-/g, '_') + '__';
       let moduleImport = "import { default as " + moduleVar + " } from '" + moduleImportPath + "';";
       moduleImports.push(moduleImport);
@@ -95,7 +95,7 @@ ResolutionMapBuilder.prototype.build = function() {
     }
   });
 
-  let destPath = path.join(this.outputPath, 'config');
+  let destPath = path.posix.join(this.outputPath, 'config');
   if (!fs.existsSync(destPath)) {
     fs.mkdirSync(destPath);
   }
@@ -103,8 +103,8 @@ ResolutionMapBuilder.prototype.build = function() {
   let contents = moduleImports.join('\n') + '\n' +
     "export default {" + mapContents.join(',') + "};" + '\n';
 
-  fs.writeFileSync(path.join(this.outputPath, 'config', 'module-map.js'), contents, { encoding: 'utf8' });
-  fs.writeFileSync(path.join(this.outputPath, 'config', 'module-map.d.ts'), INTERFACE, { encoding: 'utf8' });
+  fs.writeFileSync(path.posix.join(this.outputPath, 'config', 'module-map.js'), contents, { encoding: 'utf8' });
+  fs.writeFileSync(path.posix.join(this.outputPath, 'config', 'module-map.d.ts'), INTERFACE, { encoding: 'utf8' });
 };
 
 module.exports = ResolutionMapBuilder;


### PR DESCRIPTION
By default, `path.join()` on Windows will use backslashes. While this works fine for file system access directly, it will break strings written to code files for obvious reasons (i.e. creating unintentional valid and invalid escape sequences), which then results in build errors, even for fresh templates:

```
Serving on http://localhost:4200/
The Broccoli Plugin: [RollupWithDependencies] failed with:
Error: <project-path>/tmp/rollup_with_dependencies-cache_path-sCSx6c9l.tmp/config/module-map.js: Bad character escape sequence (1:74)
    at error (<project-path>\node_modules\rollup\dist\rollup.js:170:12)
    at <project-path>\node_modules\rollup\dist\rollup.js:8937:6

The broccoli plugin was instantiated at:
    at RollupWithDependencies.Plugin (<project-path>\node_modules\broccoli-plugin\index.js:7:31)
    at RollupWithDependencies.Rollup (<project-path>\node_modules\broccoli-rollup\dist\index.js:74:72)
    at new RollupWithDependencies (<project-path>\node_modules\@glimmer\application-pipeline\dist\commonjs\es5\broccoli\rollup-with-dependencies.js:63:57)
    at GlimmerApp.rollupTree (<project-path>\node_modules\@glimmer\application-pipeline\dist\commonjs\es5\broccoli\glimmer-app.js:286:16)
    at GlimmerApp.javascriptTree (<project-path>\node_modules\@glimmer\application-pipeline\dist\commonjs\es5\broccoli\glimmer-app.js:267:21)
    at GlimmerApp.toTree (<project-path>\node_modules\@glimmer\application-pipeline\dist\commonjs\es5\broccoli\glimmer-app.js:212:27)
    at module.exports (<project-path>\ember-cli-build.js:23:14)
    at Builder.setupBroccoliBuilder (<project-path>\node_modules\ember-cli\lib\models\builder.js:54:19)
    at new Builder (<project-path>\node_modules\ember-cli\lib\models\builder.js:33:10)
    at ServeTask.run (<project-path>\node_modules\ember-cli\lib\tasks\serve.js:15:19)