### PR TITLE
Ignore TypeScript declaration files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ ResolutionMapBuilder.prototype.build = function() {
   modulePaths.forEach(function(modulePath) {
     let pathParts = path.parse(modulePath);
 
-    if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1) {
+    if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1 || pathParts.base.slice(-5) === '.d.ts') {
       return;
     }
 

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -33,6 +33,7 @@ describe('resolution-map-builder', function() {
                     "ignore-me.ts": ""
                   },
                   "component.ts": "",
+                  "ignore-me.d.ts": "",
                   "template.hbs": "",
                   "titleize.ts": ""
                 },


### PR DESCRIPTION
This solves errors when an application has a `.d.ts` file.

cc/ @rwjblue.