### PR TITLE
Fix various issues with invalid output.

### DIFF
--- a/lib/get-module-specifier.js
+++ b/lib/get-module-specifier.js
@@ -6,8 +6,8 @@ module.exports = function(modulePrefix, moduleConfig, modulePath, moduleExtensio
 
     // TODO allow this setting in the resolver config
     const defaultTypesByExtension = {
-      'hbs': 'template',
-      'handlebars': 'template'
+      '.hbs': 'template',
+      '.handlebars': 'template'
     };
 
     // console.log('path', modulePath, 'extension', moduleExtension);

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,8 +76,9 @@ ResolutionMapBuilder.prototype.build = function() {
   }
 
   mappedPaths.forEach(modulePath => {
-    let module = modulePath.substring(0, modulePath.lastIndexOf('.'));
-    let extension = modulePath.substring(modulePath.lastIndexOf('.') + 1);
+    let pathParts = path.parse(modulePath);
+    let module = path.posix.join(pathParts.dir, pathParts.name);
+    let extension = pathParts.ext;
     let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module, extension);
 
     // Only process non-null specifiers returned.

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,22 @@ declare let map: Dict<any>;
 export default map;
 `;
 
+function getModuleIdentifier(seen, modulePath) {
+  let identifier = modulePath
+      // replace any non letter, non-number, non-underscore
+      .replace(/[\W]/g, '_');
+
+  // if we have already generated this identifier
+  // prefix with an _ until we find a unique one
+  while (seen[identifier]) {
+    identifier = `_${identifier}`;
+  }
+
+  seen[identifier] = modulePath;
+
+  return `__${identifier}__`;
+}
+
 function ResolutionMapBuilder(src, config, options) {
   options = options || {};
   Plugin.call(this, [src, config], {
@@ -77,6 +93,7 @@ ResolutionMapBuilder.prototype.build = function() {
   }
 
   let seenSpecifiers = Object.create(null);
+  let seenModuleVars = Object.create(null);
 
   mappedPaths.forEach(modulePath => {
     let pathParts = path.parse(modulePath);
@@ -94,7 +111,7 @@ ResolutionMapBuilder.prototype.build = function() {
     // Specifiers may be null in the case of an unresolvable collection (e.g. utils)
     if (specifier) {
       let moduleImportPath = path.posix.join('..', baseDir, module);
-      let moduleVar = '__' + module.replace(/\//g, '__').replace(/-/g, '_') + '__';
+      let moduleVar = getModuleIdentifier(seenModuleVars, module);
       let moduleImport = "import { default as " + moduleVar + " } from '" + moduleImportPath + "';";
       moduleImports.push(moduleImport);
       mapContents.push("'" + specifier + "': " + moduleVar);
@@ -118,3 +135,4 @@ ResolutionMapBuilder.prototype.build = function() {
 };
 
 module.exports = ResolutionMapBuilder;
+module.exports._getModuleIdentifier = getModuleIdentifier;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const path = require('path');
 const walkSync = require('walk-sync');
 const getModuleConfig = require('./get-module-config');
 const getModuleSpecifier = require('./get-module-specifier');
+const SilentError = require('silent-error');
 
 const IGNORED_EXTENSIONS = ['', '.md', '.html'];
 const INTERFACE = `
@@ -75,11 +76,19 @@ ResolutionMapBuilder.prototype.build = function() {
     this.specifiers = [];
   }
 
+  let seenSpecifiers = Object.create(null);
+
   mappedPaths.forEach(modulePath => {
     let pathParts = path.parse(modulePath);
     let module = path.posix.join(pathParts.dir, pathParts.name);
     let extension = pathParts.ext;
     let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module, extension);
+
+    if (seenSpecifiers[specifier]) {
+      throw new SilentError(`Both \`${seenSpecifiers[specifier]}\` and \`${modulePath}\` represent ${specifier}, please rename one to remove the collision.`);
+    } else {
+      seenSpecifiers[specifier] = modulePath;
+    }
 
     // Only process non-null specifiers returned.
     // Specifiers may be null in the case of an unresolvable collection (e.g. utils)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "broccoli-plugin": "^1.3.0",
+    "silent-error": "^1.0.1",
     "walk-sync": "^0.3.1"
   },
   "devDependencies": {

--- a/test/get-module-specifier-test.js
+++ b/test/get-module-specifier-test.js
@@ -53,7 +53,7 @@ describe('get-module-specifier', function() {
 
   it('identifies named modules in the root of a collection as the default type for that collection', function() {
     let modulePath = 'ui/components/text-editor';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/components/text-editor'
     );
@@ -61,7 +61,7 @@ describe('get-module-specifier', function() {
 
   it('identifies named modules in the root of a collection as the default type for their extension', function() {
     let modulePath = 'ui/components/text-editor';
-    let moduleExtension = 'hbs';
+    let moduleExtension = '.hbs';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'template:/my-app/components/text-editor'
     );
@@ -69,7 +69,7 @@ describe('get-module-specifier', function() {
 
   it('identifies name/type modules in a collection', function() {
     let modulePath = 'ui/components/text-editor/component';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/components/text-editor'
     );
@@ -77,7 +77,7 @@ describe('get-module-specifier', function() {
 
   it('identifies name/type modules with an extension that has a default type', function() {
     let modulePath = 'ui/components/text-editor/template';
-    let moduleExtension = 'hbs';
+    let moduleExtension = '.hbs';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'template:/my-app/components/text-editor'
     );
@@ -85,7 +85,7 @@ describe('get-module-specifier', function() {
 
   it('identifies namespace/name/type modules in a collection', function() {
     let modulePath = 'ui/components/edit-form/text-editor/component';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/components/edit-form/text-editor'
     );
@@ -93,7 +93,7 @@ describe('get-module-specifier', function() {
 
   it('identifies namespace/name modules as the default type for a collection', function() {
     let modulePath = 'ui/components/edit-form/text-editor';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/components/edit-form/text-editor'
     );
@@ -101,7 +101,7 @@ describe('get-module-specifier', function() {
 
   it('identifies namespace/name modules as the default type for their extension', function() {
     let modulePath = 'ui/components/edit-form/text-editor';
-    let moduleExtension = 'hbs';
+    let moduleExtension = '.hbs';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'template:/my-app/components/edit-form/text-editor'
     );
@@ -109,7 +109,7 @@ describe('get-module-specifier', function() {
 
   it('identifies modules as the default type in private collections', function() {
     let modulePath = 'ui/routes/posts/-components/edit-form';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/routes/posts/-components/edit-form'
     );
@@ -117,7 +117,7 @@ describe('get-module-specifier', function() {
 
   it('identifies modules in private collections as the default type for their extension', function() {
     let modulePath = 'ui/routes/posts/-components/edit-form';
-    let moduleExtension = 'hbs';
+    let moduleExtension = '.hbs';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'template:/my-app/routes/posts/-components/edit-form'
     );
@@ -125,7 +125,7 @@ describe('get-module-specifier', function() {
 
   it('identifies namespace/name/type modules in a private collection', function() {
     let modulePath = 'ui/routes/posts/-components/edit-form/text-editor/component';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       'component:/my-app/routes/posts/-components/edit-form/text-editor'
     );
@@ -133,7 +133,7 @@ describe('get-module-specifier', function() {
 
   it('returns null for modules in unresolvable collections', function() {
     let modulePath = 'ui/routes/posts/-utils/ignore-me';
-    let moduleExtension = 'js';
+    let moduleExtension = '.js';
     assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
       null
     );

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -181,4 +181,31 @@ describe('resolution-map-builder', function() {
       'config/module-map.js'
     ]);
   }));
+
+  it('errors if two files compiled to the same specifiers', co.wrap(function* () {
+    let options = { configPath: 'environment.json', logSpecifiers: true };
+
+    yield srcFixture.dispose();
+
+    srcFixture.write({
+      "src": {
+        "ui": {
+          "components": {
+            "foo-bar.ts": 'export default class { }',
+            "foo-bar": {
+              "component.ts": 'export default class { }'
+            }
+          }
+        }
+      }
+    });
+
+    let mapBuilder = new ResolutionMapBuilder(srcFixture.path() + '/src', configFixture.path(), options);
+
+    buildOutput(mapBuilder)
+      .catch(error => {
+        assert.equal(error.name, 'Both `ui/components/foo-bar.ts` and `ui/components/foo-bar/component.ts` represent component:/my-app/components/foo-bar, please rename one to remove the collision.');
+      })
+      .then(() => assert.ok(false, 'should have errored'));
+  }));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,12 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+silent-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.0.1.tgz#71b7d503d1c6f94882b51b56be879b113cb4822c"
+  dependencies:
+    debug "^2.2.0"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"


### PR DESCRIPTION
Fixup issues around generating module identifiers.

Previously a number of issues existed:

* We only replaced `/` and `-`, but allowed through any other char.  This resulted in invalid JS when files include `.` or `#` (which are commonly used by emacs/vim as swap files or lock files).
* We would happily allow two module paths to generate the same identifier, only to later get a syntax error during Rollup due to the fact that `{ a: 'blah', a: 'blah' }` is an error.

This fixes those two issues by:

* Tracking the module identifiers that we have already seen, and ensuring that a unique one is generated each time.
* Replace all non-word characters with `_` (instead of only `-` and `/`).

---

Prevent duplicate specifiers from being generated.

Throw a helpful error when the same specifier is generated for two different modules.

---

Fixes https://github.com/glimmerjs/resolution-map-builder/issues/17