### PR TITLE
Ignore dotfiles found in `src`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,25 @@ function getModuleIdentifier(seen, modulePath) {
   return `__${identifier}__`;
 }
 
+function shouldIgnore(pathParts) {
+  // ignore any of these extensions (.md, .html, etc)
+  if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1) {
+    return true;
+  }
+
+  // ignore .d.ts files
+  if (pathParts.base.slice(-5) === '.d.ts') {
+    return true;
+  }
+
+  // ignore dotfiles
+  if (pathParts.base[0] === '.') {
+    return true;
+  }
+
+  return false;
+}
+
 function ResolutionMapBuilder(src, config, options) {
   options = options || {};
   Plugin.call(this, [src, config], {
@@ -76,7 +95,7 @@ ResolutionMapBuilder.prototype.build = function() {
   modulePaths.forEach(function(modulePath) {
     let pathParts = path.parse(modulePath);
 
-    if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1 || pathParts.base.slice(-5) === '.d.ts') {
+    if (shouldIgnore(pathParts)) {
       return;
     }
 
@@ -136,3 +155,4 @@ ResolutionMapBuilder.prototype.build = function() {
 
 module.exports = ResolutionMapBuilder;
 module.exports._getModuleIdentifier = getModuleIdentifier;
+module.exports._shouldIgnore = shouldIgnore;

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -2,6 +2,7 @@
 
 const ResolutionMapBuilder = require('..');
 const getModuleIdentifier = ResolutionMapBuilder._getModuleIdentifier;
+const shouldIgnore = ResolutionMapBuilder._shouldIgnore;
 const path = require('path');
 const fs = require('fs');
 const co = require('co');
@@ -236,5 +237,29 @@ describe('resolution-map-builder', function() {
         );
       });
     });
+  });
+
+  describe('shouldIgnore', function() {
+    function generateTest(modulePath, expected) {
+      it(`${expected ? 'should ignore' : 'should not ignore'} ${modulePath}`, function() {
+        let pathParts = path.parse(modulePath);
+
+        assert.equal(shouldIgnore(pathParts), expected);
+      });
+    }
+
+    let cases = {
+      'src/ui/components/foo-bar.ts': false,
+      'src/ui/components/.foo-bar.ts': true,
+      'src/ui/components/other.d.ts': true,
+      'src/ui/components/foo-bar.md': true,
+      'src/ui/index.html': true,
+      'src/ui/components/README.md': true,
+      'src/ui/.eslintrc': true
+    };
+
+    for (let modulePath in cases) {
+      generateTest(modulePath, cases[modulePath]);
+    }
   });
 });


### PR DESCRIPTION
It seems reasonable to ignore dot files in the module map. The most common scenario for this would be something like `.eslintrc`, `.gitkeep`, etc.

Vim also happens to create `.<file-name-here>` files as swap files.

@dgeb - r?