### PR TITLE
Refactor to use `IGNORED_PREFIXES` and `IGNORED_SUFFIXES`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,9 @@ const getModuleSpecifier = require('./get-module-specifier');
 const SilentError = require('silent-error');
 
 const IGNORED_EXTENSIONS = ['', '.md', '.html'];
+const IGNORED_SUFFIXES = ['.d.ts'];
+const IGNORED_PREFIXES = ['.'];
+
 const INTERFACE = `
 export interface Dict<T> {
     [index: string]: T;
@@ -39,13 +42,13 @@ function shouldIgnore(pathParts) {
     return true;
   }
 
-  // ignore .d.ts files
-  if (pathParts.base.slice(-5) === '.d.ts') {
+  // ignore .d.ts files, etc
+  if (IGNORED_SUFFIXES.some(suffix => pathParts.base.endsWith(suffix))) {
     return true;
   }
 
   // ignore dotfiles
-  if (pathParts.base[0] === '.') {
+  if (IGNORED_PREFIXES.some(prefix => pathParts.base.startsWith(prefix))) {
     return true;
   }
 


### PR DESCRIPTION
Removes hard coded checks for `.d.ts` suffix and `.` prefix, by refactoring to an array for easier extension as new patterns emerge...

Addresses some comments brought up in #19.