### PR TITLE
Adds tests for dot delimeter resolutions

### DIFF
--- a/lib/get-module-specifier.js
+++ b/lib/get-module-specifier.js
@@ -27,7 +27,7 @@ module.exports = function(modulePrefix, moduleConfig, modulePath, moduleExtensio
       collectionPath = 'main';
     }
 
-    let name, type; 
+    let name, type;
     let rootCollectionName = moduleConfig.collectionMap[collectionPath];
     let rootCollection = moduleConfig.collections[rootCollectionName];
     let parts = modulePath.split('/');
@@ -52,6 +52,10 @@ module.exports = function(modulePrefix, moduleConfig, modulePath, moduleExtensio
     if (collection.unresolvable) {
       return null;
     }
+
+    // normalize the path for the specifier
+    // in the case `managerId` is present
+    parts = parts.map(path => path.split('.')[0]);
 
     let part = parts[parts.length - 1];
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha test --recursive"
+    "test": "mocha test --recursive",
+    "test:debug": "mocha --no-timeouts debug"
   },
   "keywords": [
     "broccoli-plugin"

--- a/test/get-module-specifier-test.js
+++ b/test/get-module-specifier-test.js
@@ -59,6 +59,17 @@ describe('get-module-specifier', function() {
     );
   });
 
+  it('identifies named module with a dot delimeter', function() {
+    let moduleExtension = '.hbs';
+
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, 'ui/components/text-editor.glimmer', moduleExtension),
+      'template:/my-app/components/text-editor'
+    );
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, 'ui/routes/posts/-components/edit-form.glimmer', moduleExtension),
+      'template:/my-app/routes/posts/-components/edit-form'
+    );
+  });
+
   it('identifies named modules in the root of a collection as the default type for their extension', function() {
     let modulePath = 'ui/components/text-editor';
     let moduleExtension = '.hbs';


### PR DESCRIPTION
This PR is a part of the journey to marry two component worlds of Glimmer and Ember.

As it turns out, this works out-of-the-box.

Related [Custom Components RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md)