### PR TITLE
Expose resolution map building primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,172 @@
 # resolution-map-builder [![Build Status](https://secure.travis-ci.org/glimmerjs/resolution-map-builder.svg?branch=master)](http://travis-ci.org/glimmerjs/resolution-map-builder)
 
-A Broccoli plugin for building a resolution map compatible with
+Utilities and a Broccoli plugin for building a resolution map compatible with
 [@glimmerjs/resolver](https://github.com/glimmerjs/glimmer-resolver)
 and the expectations of Ember's
 [module unification RFC](https://github.com/emberjs/rfcs/blob/master/text/0143-module-unification.md).
 
+This package is a low-level utility and most people should not need to use it
+directly. A new Glimmer app will be configured to generate the resolution map
+automatically via the
+[`@glimmer/application-pipeline`](http://github.com/glimmerjs/glimmer-application-pipeline)
+package.
+
+## The Resolution Map
+
+Glimmer uses a [resolver](https://github.com/glimmerjs/glimmer-resolver) to
+locate your app's modules. For example, if you use the component
+`<my-component>` in a template, the resolver is what tells Glimmer that that
+component lives in your app's `src/ui/components/my-component/component.ts`
+file.
+
+To make this process fast, Glimmer generates a _resolution map_ when you build
+your application. This resolution map allows the resolver to quickly locate the
+requested object.
+
+### Specifiers
+
+Internally, Glimmer uses _specifiers_ to identify objects in the system. A
+specifier is a specially-formatted string that encodes the _type_ and _path_ of
+an object.
+
+For example, the specifier for the `text-editor` component's template in an app might be:
+
+```js
+"template:/my-app/components/text-editor"
+```
+
+In addition to the type of object (component, template, route, etc.), a
+specifier's path includes information about the root name (an app or an addon),
+collection, and namespace.
+
+### Generated Source
+
+This package can generate the source code for a JavaScript module that imports
+the files in your app and includes them in a resolution map object. For example:
+
+```js
+import { default as __ui_components_my_app_component_ts__ } from '../ui/components/my-app/component.ts';
+import { default as __ui_components_my_app_page_banner_component_ts__ } from '../ui/components/my-app/page-banner/component.ts';
+import { default as __ui_components_my_app_page_banner_template_hbs__ } from '../ui/components/my-app/page-banner/template.hbs';
+import { default as __ui_components_my_app_page_banner_titleize_ts__ } from '../ui/components/my-app/page-banner/titleize.ts';
+import { default as __ui_components_my_app_template_hbs__ } from '../ui/components/my-app/template.hbs';
+import { default as __ui_components_text_editor_hbs__ } from '../ui/components/text-editor.hbs';
+import { default as __ui_components_text_editor_ts__ } from '../ui/components/text-editor.ts';
+export default {'component:/my-app/components/my-app': __ui_components_my_app_component_ts__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component_ts__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template_hbs__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize_ts__,'template:/my-app/components/my-app': __ui_components_my_app_template_hbs__,'template:/my-app/components/text-editor': __ui_components_text_editor_hbs__,'component:/my-app/components/text-editor': __ui_components_text_editor_ts__};
+```
+
+## Usage
+
+### Broccoli Plugin
+
+If using as a Broccoli plugin, instantiate the plugin with two input trees:
+
+1. The `src` directory
+2. The `config` directory
+
+```js
+const ResolutionMapBuilder = require('@glimmer/resolution-map-builder');
+return new ResolutionMapBuilder(srcTree, configTree, {
+  srcDir: 'src',
+  defaultModulePrefix: this.name,
+  defaultModuleConfiguration
+});
+```
+
+The Broccoli plugin will read the module prefix and module configuration from
+the `configTree`. If none are found, you can still provide fallback
+configurations with the `defaultModulePrefix` and `defaultModuleConfiguration`
+options.
+
+### Utilities
+
+If you want to generate your own resolution map without using Broccoli, this
+package includes several helper functions you can use.
+
+#### `buildResolutionMapSource()`
+
+Returns a string of generated JavaScript that imports each module and has a default export of
+an object with specifiers as keys and each module's default export as its value.
+
+```js
+const { buildResolutionMapSource } = require('@glimmer/resolution-map-builder');
+let moduleConfig = {
+  types: {
+    application: { definitiveCollection: 'main' },
+    component: { definitiveCollection: 'components' },
+    helper: { definitiveCollection: 'components' },
+    renderer: { definitiveCollection: 'main' },
+    template: { definitiveCollection: 'components' }
+  },
+  collections: {
+    main: {
+      types: ['application', 'renderer']
+    },
+    components: {
+      group: 'ui',
+      types: ['component', 'template', 'helper'],
+      defaultType: 'component',
+      privateCollections: ['utils']
+    },
+    styles: {
+      group: 'ui',
+      unresolvable: true
+    },
+    utils: {
+      unresolvable: true
+    }
+  }
+};
+
+let contents = buildResolutionMapSource({
+  projectDir: 'path/to/app',
+  srcDir: 'src',
+  modulePrefix: 'my-app',
+  moduleConfig
+});
+// returns
+// `import { default as __ui_components_my_app_component_ts__ } from '../ui/components/my-app/component.ts';
+// export default { 'component:/my-app/components/my-app': __ui_components_my_app_component_ts__ };`
+
+fs.writeFileSync('config/module-map.js', contents, { encoding: 'utf8' });
+```
+
+#### `buildResolutionMapTypeDefinitions()`
+
+Returns a string of TypeScript source code that provides type information for
+the resolution map generated by `buildResolutionMapSource()`. This source can be
+included in a `.d.ts` file with the same name as the resolution map to avoid
+TypeScript errors at compilation time.
+
+```js
+const { buildResolutionMapTypeDefinitions } = require('@glimmer/resolution-map-builder');
+
+let types = buildResolutionMapTypeDefinitions();
+fs.writeFileSync('config/module-map.d.ts', types, { encoding: 'utf8' });
+```
+
+#### `buildResolutionMap()`
+
+Similar to `buildResolutionMapSource()` (and takes the same arguments), but
+allows you to generate the JavaScript output yourself. Instead of returning
+JavaScript source, `buildResolutionMap()` returns an object with module
+specifiers as the keys and the _path_ to the module (relative to `projectDir`)
+as the value.
+
+```js
+const { buildResolutionMap } = require('@glimmer/resolution-map-builder');
+
+let map = buildResolutionMap({
+  projectDir: 'path/to/app',
+  srcDir: 'src',
+  modulePrefix: 'my-app',
+  moduleConfig
+});
+
+// returns {
+//   'component:/my-app/components/my-app': 'src/ui/components/my-app/component.ts'
+// }
+```
 
 ## Acknowledgements
 

--- a/lib/build-resolution-map-source.js
+++ b/lib/build-resolution-map-source.js
@@ -42,16 +42,17 @@ module.exports = function(options) {
     let moduleImportPath = path.posix.join(configToSrcPath, modulePath);
 
     let moduleVar = getModuleIdentifier(seenModuleVars, modulePath);
-    let moduleImport = "import { default as " + moduleVar + " } from '" + moduleImportPath + "';";
+    let moduleImport = `import { default as ${moduleVar} } from '${moduleImportPath}';`;
     moduleImports.push(moduleImport);
-    mapContents.push("'" + specifier + "': " + moduleVar);
+    mapContents.push(`'${specifier}': ${moduleVar}`);
 
     if (options.logSpecifiers) {
       options.logSpecifiers.push(specifier);
     }
   }
 
-  return moduleImports.join('\n') + '\n' +
-    "export default {" + mapContents.join(',') + "};" + '\n';
+  return moduleImports.join('\n') + `
+export default {${mapContents.join(',')}};
+`;
 }
 

--- a/lib/build-resolution-map-source.js
+++ b/lib/build-resolution-map-source.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const path = require('path');
+
+const buildResolutionMap = require('./build-resolution-map');
+const getModuleIdentifier = require('./get-module-identifier');
+
+/**
+ * Generates the JavaScript source code for a resolution map module. The
+ * generated source code imports all of the resolved modules, and exports an
+ * object that contains specifiers as keys and the module's default export as
+ * the value.
+ * 
+ * @param {Object} options - configuration options for generating the map
+ * @param {ModuleConfig} options.moduleConfig - the module config object
+ * @param {string} options.modulePrefix - the name of the package the resolution map is being generated for (e.g., the app name)
+ * @param {string} options.projectDir - the path to the application or addon root directory
+ * @param {string} [options.srcDir=src] - the path of the directory that contains resolvable modules, relative to projectDir
+ * @param {string} [options.configPath=config] - the path of the directory where the resolution map will be written, relative to projectDir
+ * @param {object} [options.resolutionMap] - a pre-built dictionary with specifiers as keys and module paths as values
+ * @param {array} [options.logSpecifiers] - if an array is passed as the logSpecifiers option, encountered specifier strings will be pushed into it
+ * 
+ * @returns {string} generated source code
+ */
+module.exports = function(options) {
+  let resolutionMap = options.resolutionMap;
+
+  let srcDir = options.srcDir === undefined ? 'src' : options.srcDir;
+  let configDir = options.configDir === undefined ? 'config' : options.configDir;
+  let configToSrcPath = path.posix.relative(configDir, srcDir);
+
+  if (!resolutionMap) {
+    resolutionMap = buildResolutionMap(options);
+  }
+
+  let seenModuleVars = Object.create(null);
+  let moduleImports = [];
+  let mapContents = [];
+
+  for (let specifier in resolutionMap) {
+    let modulePath = resolutionMap[specifier];
+    let moduleImportPath = path.posix.join(configToSrcPath, modulePath);
+
+    let moduleVar = getModuleIdentifier(seenModuleVars, modulePath);
+    let moduleImport = "import { default as " + moduleVar + " } from '" + moduleImportPath + "';";
+    moduleImports.push(moduleImport);
+    mapContents.push("'" + specifier + "': " + moduleVar);
+
+    if (options.logSpecifiers) {
+      options.logSpecifiers.push(specifier);
+    }
+  }
+
+  return moduleImports.join('\n') + '\n' +
+    "export default {" + mapContents.join(',') + "};" + '\n';
+}
+

--- a/lib/build-resolution-map.js
+++ b/lib/build-resolution-map.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const path = require('path');
+const walkSync = require('walk-sync');
+const SilentError = require('silent-error');
+
+const getModuleConfig = require('./get-module-config');
+const getModuleSpecifier = require('./get-module-specifier');
+const shouldIgnore = require('./should-ignore');
+
+/**
+ * Given a module config, module prefix and input directory, returns
+ * a dictionary with module specifier as the key and the module path (relative
+ * to the input directory) as the value.
+ * 
+ * For example, given this directory:
+ * 
+ *     src/
+ *       ui/
+ *         components/
+ *           user-avatar/
+ *             template.hbs
+ *             component.js
+ * 
+ * This function returns:
+ * 
+ *     {
+ *       "component:/my-app/components/my-app": "ui/components/user-avatar/component.js",
+ *       "template:/my-app/components/my-app": "ui/components/user-avatar/template.hbs"
+ *     }
+ * 
+ * @param {object} options - configuration options for generating the map
+ * @param {ModuleConfig} options.moduleConfig - the module config object
+ * @param {string} options.modulePrefix - the name of the package the resolution map is being generated for (e.g., the app name)
+ * @param {string} options.projectDir - the path to the application or addon root directory
+ * @param {string} [options.srcDir=src] - the path of the directory that contains resolvable modules, relative to projectDir
+ */
+module.exports = function(options) {
+  validateOptions(options);
+
+  let { moduleConfig, modulePrefix, srcDir, projectDir } = options;
+  moduleConfig = getModuleConfig(moduleConfig);
+
+  srcDir = srcDir === undefined ? 'src' : srcDir;
+
+  let rootPath = path.join(projectDir, srcDir);
+  let mappedPaths = [];
+
+  // Build an array containing all recursive files and directories in the root
+  // directory.
+  let modulePaths = walkSync(rootPath);
+
+  // Filter out modules that should be ignored.
+  modulePaths.forEach(function(modulePath) {
+    let pathParts = path.parse(modulePath);
+
+    if (shouldIgnore(pathParts)) {
+      return;
+    }
+
+    let name = path.posix.join(pathParts.dir, pathParts.name);
+
+    // filter out index module
+    if (name !== 'index' && name !== 'main') {
+      mappedPaths.push(modulePath);
+    }
+  });
+
+  let resolutionMap = Object.create(null);
+
+  // Loop through module paths and create an entry in the resolution map, from
+  // specifier to module path.
+  mappedPaths.forEach(modulePath => {
+    let pathParts = path.parse(modulePath);
+    let module = path.posix.join(pathParts.dir, pathParts.name);
+    let extension = pathParts.ext;
+    let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module, extension);
+
+    // Only process non-null specifiers returned.
+    // Specifiers may be null in the case of an unresolvable collection (e.g. utils)
+    if (specifier) {
+      if (resolutionMap[specifier]) {
+        throw new SilentError(`Both \`${resolutionMap[specifier]}\` and \`${modulePath}\` represent ${specifier}, please rename one to remove the collision.`);
+      } else {
+        resolutionMap[specifier] = modulePath;
+      }
+    }
+  });
+
+  return resolutionMap;
+}
+
+function validateOptions(options) {
+  if (typeof options !== 'object') {
+    throw new Error('You must pass an options object to buildResolutionMap.');
+  }
+
+  if (typeof options.moduleConfig !== 'object') {
+    throw new Error('You must pass a module configuration object to buildResolutionMap, like buildResolutionMap({ moduleConfig: ... }).');
+  }
+
+  if (typeof options.modulePrefix !== 'string') {
+    throw new Error('You must pass the module prefix string to buildResolutionMap, like buildResolutionMap({ modulePrefix: "app" }).');
+  }
+
+  if (typeof options.projectDir !== 'string') {
+    throw new Error('You must pass the app or addon path to buildResolutionMap, like buildResolutionMap({ projectDir: "my-app" }).');
+  }
+}

--- a/lib/build-resolution-map.js
+++ b/lib/build-resolution-map.js
@@ -38,8 +38,10 @@ const shouldIgnore = require('./should-ignore');
 module.exports = function(options) {
   validateOptions(options);
 
-  let { moduleConfig, modulePrefix, srcDir, projectDir } = options;
-  moduleConfig = getModuleConfig(moduleConfig);
+  let moduleConfig = getModuleConfig(options.moduleConfig);
+  let modulePrefix = options.modulePrefix;
+  let srcDir = options.srcDir;
+  let projectDir = options.projectDir;
 
   srcDir = srcDir === undefined ? 'src' : srcDir;
 

--- a/lib/get-module-config.js
+++ b/lib/get-module-config.js
@@ -20,7 +20,5 @@ module.exports = function(json) {
   moduleConfig.collectionMap = collectionMap;
   moduleConfig.collectionPaths = collectionPaths;
 
-  // console.log('moduleConfig', moduleConfig);
-
   return moduleConfig;
 };

--- a/lib/get-module-identifier.js
+++ b/lib/get-module-identifier.js
@@ -1,0 +1,22 @@
+/**
+ * Generates a valid, unique JavaScript identifier for a module path.
+ * 
+ * @param {array} seen an array of identifiers used in this scope
+ * @param {string} modulePath the module path
+ * @returns {string} identifier a valid JavaScript identifier
+ */
+module.exports = function getModuleIdentifier(seen, modulePath) {
+  let identifier = modulePath
+      // replace any non letter, non-number, non-underscore
+      .replace(/[\W]/g, '_');
+
+  // if we have already generated this identifier
+  // prefix with an _ until we find a unique one
+  while (seen[identifier]) {
+    identifier = `_${identifier}`;
+  }
+
+  seen[identifier] = modulePath;
+
+  return `__${identifier}__`;
+}

--- a/lib/get-module-identifier.js
+++ b/lib/get-module-identifier.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Generates a valid, unique JavaScript identifier for a module path.
  * 

--- a/lib/get-module-specifier.js
+++ b/lib/get-module-specifier.js
@@ -1,88 +1,86 @@
 'use strict';
 
-module.exports = function(modulePrefix, moduleConfig, modulePath, moduleExtension) {
-    let path;
-    let collectionPath;
+module.exports = function (modulePrefix, moduleConfig, modulePath, moduleExtension) {
+  let path;
+  let collectionPath;
 
-    // TODO allow this setting in the resolver config
-    const defaultTypesByExtension = {
-      '.hbs': 'template',
-      '.handlebars': 'template'
-    };
+  // TODO allow this setting in the resolver config
+  const defaultTypesByExtension = {
+    '.hbs': 'template',
+    '.handlebars': 'template'
+  };
 
-    // console.log('path', modulePath, 'extension', moduleExtension);
-
-    for (let i = 0, l = moduleConfig.collectionPaths.length; i < l; i++) {
-      path = moduleConfig.collectionPaths[i];
-      if (modulePath.indexOf(path) === 0) {
-        collectionPath = path;
-        break;
-      }
+  for (let i = 0, l = moduleConfig.collectionPaths.length; i < l; i++) {
+    path = moduleConfig.collectionPaths[i];
+    if (modulePath.indexOf(path) === 0) {
+      collectionPath = path;
+      break;
     }
+  }
 
-    if (collectionPath) {
-      // trim group/collection from module path
-      modulePath = modulePath.substr(collectionPath.length + 1);
-    } else {
-      collectionPath = 'main';
-    }
+  if (collectionPath) {
+    // trim group/collection from module path
+    modulePath = modulePath.substr(collectionPath.length + 1);
+  } else {
+    collectionPath = 'main';
+  }
 
-    let name, type; 
-    let rootCollectionName = moduleConfig.collectionMap[collectionPath];
-    let rootCollection = moduleConfig.collections[rootCollectionName];
-    let parts = modulePath.split('/');
+  let name, type;
+  let rootCollectionName = moduleConfig.collectionMap[collectionPath];
+  let rootCollection = moduleConfig.collections[rootCollectionName];
+  let parts = modulePath.split('/');
 
-    let collection = rootCollection;
-    let collectionName = rootCollectionName;
+  let collection = rootCollection;
+  let collectionName = rootCollectionName;
 
-    // scan for private collections
-    parts.forEach(part => {
-      if (part.indexOf('-') === 0) {
-        let privateCollectionName = part.substr(1);
+  // scan for private collections
+  parts.forEach(part => {
+    if (part.indexOf('-') === 0) {
+      let privateCollectionName = part.substr(1);
 
-        if (collection.privateCollections.indexOf(privateCollectionName) === -1) {
-          throw new Error(`The collection '${collectionName}' is not configured to contain a collection '${privateCollectionName}'`);
-        }
-
-        collectionName = privateCollectionName;
-        collection = moduleConfig.collections[collectionName];
+      if (collection.privateCollections.indexOf(privateCollectionName) === -1) {
+        throw new Error(`The collection '${collectionName}' is not configured to contain a collection '${privateCollectionName}'`);
       }
-    });
 
-    if (collection.unresolvable) {
-      return null;
+      collectionName = privateCollectionName;
+      collection = moduleConfig.collections[collectionName];
     }
+  });
 
-    let part = parts[parts.length - 1];
+  if (collection.unresolvable) {
+    return null;
+  }
 
-    if (collection.types.indexOf(part) > -1) {
-      type = parts.pop();
-      if (parts.length > 0) {
-        name = parts.pop();
-      } else {
-        throw new Error(`The name of module '${modulePath}' could not be identified`);
-      }
-    } else {
-      name = parts.pop();
-      if (defaultTypesByExtension[moduleExtension]) {
-        type = defaultTypesByExtension[moduleExtension];
-      } else if (collection.defaultType) {
-        type = collection.defaultType;
-      } else {
-        throw new Error(`The type of module '${modulePath}' could not be identified`);
-      }
-    }
+  let part = parts[parts.length - 1];
 
-    let specifierPath = [modulePrefix, rootCollectionName];
-
-    // Append any remaining parts as a namespace
+  if (collection.types.indexOf(part) > -1) {
+    type = parts.pop();
     if (parts.length > 0) {
-      Array.prototype.push.apply(specifierPath, parts);
+      name = parts.pop();
+    } else {
+      throw new Error(`The name of module '${modulePath}' could not be identified`);
     }
+  } else {
+    name = parts.pop();
+    if (defaultTypesByExtension[moduleExtension]) {
+      type = defaultTypesByExtension[moduleExtension];
+    } else if (collection.defaultType) {
+      type = collection.defaultType;
+    } else {
+      throw new Error(`The type of module '${modulePath}' could not be identified`);
+    }
+  }
 
-    specifierPath.push(name);
+  let specifierPath = [modulePrefix, rootCollectionName];
 
-    let specifier = type + ':/' + specifierPath.join('/');
+  // Append any remaining parts as a namespace
+  if (parts.length > 0) {
+    Array.prototype.push.apply(specifierPath, parts);
+  }
 
-    return specifier;
+  specifierPath.push(name);
+
+  let specifier = type + ':/' + specifierPath.join('/');
+
+  return specifier;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,14 +3,12 @@
 const Plugin = require('broccoli-plugin');
 const fs = require('fs');
 const path = require('path');
-const walkSync = require('walk-sync');
-const getModuleConfig = require('./get-module-config');
-const getModuleSpecifier = require('./get-module-specifier');
-const SilentError = require('silent-error');
 
-const IGNORED_EXTENSIONS = ['', '.md', '.html'];
-const IGNORED_SUFFIXES = ['.d.ts'];
-const IGNORED_PREFIXES = ['.'];
+const buildResolutionMap = require('./build-resolution-map');
+const buildResolutionMapSource = require('./build-resolution-map-source');
+const getModuleIdentifier = require('./get-module-identifier');
+const getModuleSpecifier = require('./get-module-specifier');
+const shouldIgnore = require('./should-ignore');
 
 const INTERFACE = `
 export interface Dict<T> {
@@ -20,39 +18,8 @@ declare let map: Dict<any>;
 export default map;
 `;
 
-function getModuleIdentifier(seen, modulePath) {
-  let identifier = modulePath
-      // replace any non letter, non-number, non-underscore
-      .replace(/[\W]/g, '_');
-
-  // if we have already generated this identifier
-  // prefix with an _ until we find a unique one
-  while (seen[identifier]) {
-    identifier = `_${identifier}`;
-  }
-
-  seen[identifier] = modulePath;
-
-  return `__${identifier}__`;
-}
-
-function shouldIgnore(pathParts) {
-  // ignore any of these extensions (.md, .html, etc)
-  if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1) {
-    return true;
-  }
-
-  // ignore .d.ts files, etc
-  if (IGNORED_SUFFIXES.some(suffix => pathParts.base.endsWith(suffix))) {
-    return true;
-  }
-
-  // ignore dotfiles
-  if (IGNORED_PREFIXES.some(prefix => pathParts.base.startsWith(prefix))) {
-    return true;
-  }
-
-  return false;
+function buildResolutionMapTypeDefinitions() {
+  return INTERFACE;
 }
 
 function ResolutionMapBuilder(src, config, options) {
@@ -61,6 +28,10 @@ function ResolutionMapBuilder(src, config, options) {
     annotation: options.annotation
   });
   this.options = options;
+
+  if (options.logSpecifiers) {
+    this.specifiers = [];
+  }
 }
 
 ResolutionMapBuilder.prototype = Object.create(Plugin.prototype);
@@ -78,7 +49,7 @@ ResolutionMapBuilder.prototype.build = function() {
     config = {};
   }
 
-  let moduleConfig = getModuleConfig(config.moduleConfiguration || this.options.defaultModuleConfiguration);
+  let moduleConfig = config.moduleConfiguration || this.options.defaultModuleConfiguration;
   if (!moduleConfig) {
     throw new Error(`The module configuration could not be found. Please add a config file to '${configPath}' and export an object with a 'moduleConfiguration' member.`);
   }
@@ -88,60 +59,14 @@ ResolutionMapBuilder.prototype.build = function() {
     throw new Error(`The module prefix could not be found. Add a config file to '${configPath}' and export an object with a 'modulePrefix' member.`);
   }
 
-  let baseDir = this.options.baseDir || '';
-  let modulePath = path.posix.join(this.inputPaths[0], baseDir);
-  let modulePaths = walkSync(modulePath);
-  let mappedPaths = [];
-  let moduleImports = [];
-  let mapContents = [];
+  let srcDir = this.options.srcDir || '';
 
-  modulePaths.forEach(function(modulePath) {
-    let pathParts = path.parse(modulePath);
-
-    if (shouldIgnore(pathParts)) {
-      return;
-    }
-
-    let name = path.posix.join(pathParts.dir, pathParts.name);
-
-    // filter out index module
-    if (name !== 'index' && name !== 'main') {
-      mappedPaths.push(modulePath);
-    }
-  });
-
-  if (this.options.logSpecifiers) {
-    this.specifiers = [];
-  }
-
-  let seenSpecifiers = Object.create(null);
-  let seenModuleVars = Object.create(null);
-
-  mappedPaths.forEach(modulePath => {
-    let pathParts = path.parse(modulePath);
-    let module = path.posix.join(pathParts.dir, pathParts.name);
-    let extension = pathParts.ext;
-    let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module, extension);
-
-    // Only process non-null specifiers returned.
-    // Specifiers may be null in the case of an unresolvable collection (e.g. utils)
-    if (specifier) {
-      if (seenSpecifiers[specifier]) {
-        throw new SilentError(`Both \`${seenSpecifiers[specifier]}\` and \`${modulePath}\` represent ${specifier}, please rename one to remove the collision.`);
-      } else {
-        seenSpecifiers[specifier] = modulePath;
-      }
-
-      let moduleImportPath = path.posix.join('..', baseDir, module);
-      let moduleVar = getModuleIdentifier(seenModuleVars, module);
-      let moduleImport = "import { default as " + moduleVar + " } from '" + moduleImportPath + "';";
-      moduleImports.push(moduleImport);
-      mapContents.push("'" + specifier + "': " + moduleVar);
-
-      if (this.options.logSpecifiers) {
-        this.specifiers.push(specifier);
-      }
-    }
+  let contents = buildResolutionMapSource({
+    projectDir: this.inputPaths[0],
+    logSpecifiers: this.specifiers,
+    srcDir,
+    moduleConfig,
+    modulePrefix
   });
 
   let destPath = path.posix.join(this.outputPath, 'config');
@@ -149,13 +74,14 @@ ResolutionMapBuilder.prototype.build = function() {
     fs.mkdirSync(destPath);
   }
 
-  let contents = moduleImports.join('\n') + '\n' +
-    "export default {" + mapContents.join(',') + "};" + '\n';
-
-  fs.writeFileSync(path.posix.join(this.outputPath, 'config', 'module-map.js'), contents, { encoding: 'utf8' });
-  fs.writeFileSync(path.posix.join(this.outputPath, 'config', 'module-map.d.ts'), INTERFACE, { encoding: 'utf8' });
+  fs.writeFileSync(path.posix.join(destPath, 'module-map.js'), contents, { encoding: 'utf8' });
+  fs.writeFileSync(path.posix.join(destPath, 'module-map.d.ts'), INTERFACE, { encoding: 'utf8' });
 };
 
 module.exports = ResolutionMapBuilder;
 module.exports._getModuleIdentifier = getModuleIdentifier;
+module.exports._getModuleSpecifier = getModuleSpecifier;
 module.exports._shouldIgnore = shouldIgnore;
+module.exports.buildResolutionMap = buildResolutionMap;
+module.exports.buildResolutionMapSource = buildResolutionMapSource;
+module.exports.buildResolutionMapTypeDefinitions = buildResolutionMapTypeDefinitions;

--- a/lib/should-ignore.js
+++ b/lib/should-ignore.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const IGNORED_EXTENSIONS = ['', '.md', '.html'];
+const IGNORED_SUFFIXES = ['.d.ts'];
+const IGNORED_PREFIXES = ['.'];
+
+/*
+ * Returns true if the passed path.parse() object should be ignored.
+ */
+function shouldIgnore(pathParts) {
+  // ignore any of these extensions (.md, .html, etc)
+  if (IGNORED_EXTENSIONS.indexOf(pathParts.ext) > -1) {
+    return true;
+  }
+
+  // ignore .d.ts files, etc
+  if (IGNORED_SUFFIXES.some(suffix => pathParts.base.endsWith(suffix))) {
+    return true;
+  }
+
+  // ignore dotfiles
+  if (IGNORED_PREFIXES.some(prefix => pathParts.base.startsWith(prefix))) {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = shouldIgnore;

--- a/test/build-resolution-map-source-test.js
+++ b/test/build-resolution-map-source-test.js
@@ -1,0 +1,65 @@
+const { buildResolutionMapSource } = require('..');
+const { createTempDir } = require('broccoli-test-helper');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+describe('buildResolutionMapSource', function () {
+  let configPath = path.join(__dirname, 'fixtures/config/environment.json');
+  let config = JSON.parse(fs.readFileSync(configPath));
+  let srcFixture;
+
+  beforeEach(function () {
+    return createTempDir().then(src => {
+      srcFixture = src;
+
+      srcFixture.write({
+        "src": {
+          "ui": {
+            "components": {
+              "my-app": {
+                "README.md": "## My-App Component\n",
+                "component.ts": "",
+                "page-banner": {
+                  "-utils": {
+                    "ignore-me.ts": ""
+                  },
+                  "component.ts": "",
+                  "ignore-me.d.ts": "",
+                  "template.hbs": "",
+                  "titleize.ts": ""
+                },
+                "template.hbs": ""
+              },
+              "text-editor.hbs": "",
+              "text-editor.ts": ""
+            },
+            "index.html": "<html>\n    <head></head>\n    <body></body>\n</html>\n"
+          }
+        }
+      });
+    });
+  });
+
+  afterEach(function () {
+    srcFixture.dispose();
+  });
+
+  it('can generate JavaScript source for a resolution map module', function () {
+    let source = buildResolutionMapSource({
+      projectDir: srcFixture.path(),
+      moduleConfig: config.moduleConfiguration,
+      modulePrefix: config.modulePrefix
+    });
+
+    assert.strictEqual(source, `import { default as __ui_components_my_app_component_ts__ } from '../src/ui/components/my-app/component.ts';
+import { default as __ui_components_my_app_page_banner_component_ts__ } from '../src/ui/components/my-app/page-banner/component.ts';
+import { default as __ui_components_my_app_page_banner_template_hbs__ } from '../src/ui/components/my-app/page-banner/template.hbs';
+import { default as __ui_components_my_app_page_banner_titleize_ts__ } from '../src/ui/components/my-app/page-banner/titleize.ts';
+import { default as __ui_components_my_app_template_hbs__ } from '../src/ui/components/my-app/template.hbs';
+import { default as __ui_components_text_editor_hbs__ } from '../src/ui/components/text-editor.hbs';
+import { default as __ui_components_text_editor_ts__ } from '../src/ui/components/text-editor.ts';
+export default {'component:/my-app/components/my-app': __ui_components_my_app_component_ts__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component_ts__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template_hbs__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize_ts__,'template:/my-app/components/my-app': __ui_components_my_app_template_hbs__,'template:/my-app/components/text-editor': __ui_components_text_editor_hbs__,'component:/my-app/components/text-editor': __ui_components_text_editor_ts__};
+`);
+  });
+});

--- a/test/build-resolution-map-source-test.js
+++ b/test/build-resolution-map-source-test.js
@@ -1,5 +1,7 @@
-const { buildResolutionMapSource } = require('..');
-const { createTempDir } = require('broccoli-test-helper');
+'use strict';
+
+const buildResolutionMapSource = require('..').buildResolutionMapSource;
+const createTempDir = require('broccoli-test-helper').createTempDir;
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');

--- a/test/build-resolution-map-test.js
+++ b/test/build-resolution-map-test.js
@@ -1,5 +1,7 @@
-const { buildResolutionMap } = require('..');
-const { createTempDir } = require('broccoli-test-helper');
+'use strict';
+
+const buildResolutionMap = require('..').buildResolutionMap;
+const createTempDir = require('broccoli-test-helper').createTempDir;
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');

--- a/test/build-resolution-map-test.js
+++ b/test/build-resolution-map-test.js
@@ -1,0 +1,65 @@
+const { buildResolutionMap } = require('..');
+const { createTempDir } = require('broccoli-test-helper');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+describe('buildResolutionMap', function () {
+  let configPath = path.join(__dirname, 'fixtures/config/environment.json');
+  let config = JSON.parse(fs.readFileSync(configPath));
+  let srcFixture;
+
+  beforeEach(function () {
+    return createTempDir().then(src => {
+      srcFixture = src;
+
+      srcFixture.write({
+        "src": {
+          "ui": {
+            "components": {
+              "my-app": {
+                "README.md": "## My-App Component\n",
+                "component.ts": "",
+                "page-banner": {
+                  "-utils": {
+                    "ignore-me.ts": ""
+                  },
+                  "component.ts": "",
+                  "ignore-me.d.ts": "",
+                  "template.hbs": "",
+                  "titleize.ts": ""
+                },
+                "template.hbs": ""
+              },
+              "text-editor.hbs": "",
+              "text-editor.ts": ""
+            },
+            "index.html": "<html>\n    <head></head>\n    <body></body>\n</html>\n"
+          }
+        }
+      });
+    });
+  });
+
+  afterEach(function () {
+    srcFixture.dispose();
+  });
+
+  it('can generate a resolution map', function () {
+    let map = buildResolutionMap({
+      projectDir: srcFixture.path(),
+      moduleConfig: config.moduleConfiguration,
+      modulePrefix: config.modulePrefix
+    });
+
+    assert.deepEqual(map, {
+      'component:/my-app/components/my-app': 'ui/components/my-app/component.ts',
+      'component:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/component.ts',
+      'template:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/template.hbs',
+      'component:/my-app/components/my-app/page-banner/titleize': 'ui/components/my-app/page-banner/titleize.ts',
+      'template:/my-app/components/my-app': 'ui/components/my-app/template.hbs',
+      'template:/my-app/components/text-editor': 'ui/components/text-editor.hbs',
+      'component:/my-app/components/text-editor': 'ui/components/text-editor.ts'
+    })
+  });
+});

--- a/test/build-resolution-map-type-definitions-test.js
+++ b/test/build-resolution-map-type-definitions-test.js
@@ -1,4 +1,6 @@
-const { buildResolutionMapTypeDefinitions } = require('..');
+'use strict';
+
+const buildResolutionMapTypeDefinitions = require('..').buildResolutionMapTypeDefinitions;
 const assert = require('assert');
 
 describe('buildResolutionMapTypeDefinitions', function() {

--- a/test/build-resolution-map-type-definitions-test.js
+++ b/test/build-resolution-map-type-definitions-test.js
@@ -1,0 +1,16 @@
+const { buildResolutionMapTypeDefinitions } = require('..');
+const assert = require('assert');
+
+describe('buildResolutionMapTypeDefinitions', function() {
+  it('emits TypeScript source', function() {
+    let source = buildResolutionMapTypeDefinitions();
+
+    assert.strictEqual(source, `
+export interface Dict<T> {
+    [index: string]: T;
+}
+declare let map: Dict<any>;
+export default map;
+`);
+  });
+});

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -87,7 +87,7 @@ describe('resolution-map-builder', function() {
   }));
 
   it('can read a config file, parse modules at specified path, and log specifiers (if requested)', co.wrap(function* () {
-    let options = { configPath: 'environment.json', baseDir: 'src', logSpecifiers: true };
+    let options = { configPath: 'environment.json', srcDir: 'src', logSpecifiers: true };
 
     let mapBuilder = new ResolutionMapBuilder(srcFixture.path(), configFixture.path(), options);
 
@@ -212,7 +212,7 @@ describe('resolution-map-builder', function() {
   }));
 
   it('does not error if two files compiled to null specifiers', co.wrap(function* () {
-    let options = { configPath: 'environment.json', logSpecifiers: true };
+    let options = { configPath: 'environment.json', srcDir: 'src', logSpecifiers: true };
 
     yield srcFixture.dispose();
 
@@ -225,7 +225,7 @@ describe('resolution-map-builder', function() {
       }
     });
 
-    let mapBuilder = new ResolutionMapBuilder(srcFixture.path() + '/src', configFixture.path(), options);
+    let mapBuilder = new ResolutionMapBuilder(srcFixture.path(), configFixture.path(), options);
 
     yield buildOutput(mapBuilder);
   }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,13 +309,13 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-debug@2.2.0, debug@^2.1.1:
+debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debug@2.6.1, debug@^2.2.0:
+debug@2.6.1, debug@^2.1.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:


### PR DESCRIPTION
This PR breaks out the utilities used to construct the resolution map into exposed functions that can more easily be used by folks who can't use the Broccoli plugin.

Specifically, it exposes:

1. `buildResolutionMapSource()`, which returns the JavaScript source code written to `module-map.js` by the Broccoli plugin.
2. `buildResolutionMapTypeDefinitions()`, which returns the TypeScript declarations for that file.
3. `buildResolutionMap()`, which returns a POJO of `{ specifierKey: modulePath }`, for folks who want to generate their own JavaScript representation (using CommonJS instead of ES6 modules, say).

I also attempted a first pass at a more fleshed out README that includes conceptual details, using the Broccoli plugin, and using the helper functions.

The only (intentional) backwards-incompatible change is that I renamed the `baseDir` option to `srcDir`, because I personally struggled with understanding the meaning of its name. For the utility functions, you pass a `projectDir` (the directory to the app or addon) and a `srcDir` (the directory containing module source, or `src` by default).

If this change seems OK, I can make the corresponding update in `@glimmer/application-pipeline`. I can also still support `baseDir` and show a deprecation warning if needed.