### PR TITLE
Add TypeScript type definitions for public API

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,28 @@
+declare namespace ResolutionMapBuilder {
+  interface BuildMapOptions {
+    moduleConfig: object;
+    modulePrefix: string;
+    projectDir: string;
+    srcDir?: string;
+  }
+
+  interface BuildSourceOptions extends BuildMapOptions {
+    configPath?: string;
+    resolutionMap?: ResolutionMap;
+  }
+
+  interface ResolutionMap {
+    [specifier: string]: string;
+  }
+
+  function buildResolutionMap(options: BuildMapOptions): ResolutionMap;
+  function buildResolutionMapSource(): string;
+  function buildResolutionMapTypeDefinitions(): string;
+}
+
+declare class ResolutionMapBuilder {
+  constructor(src: string, config: any, options?: ResolutionMapBuilder.BuildMapOptions);
+  build(): void;
+}
+
+export = ResolutionMapBuilder;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "repository": "https://github.com/glimmerjs/resolution-map-builder",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "mocha test --recursive"
   },


### PR DESCRIPTION
This lets us use this package in other TypeScript packages without getting build errors.