### PR TITLE
Remove resolution map extensions and type inference by extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,12 @@ This package can generate the source code for a JavaScript module that imports
 the files in your app and includes them in a resolution map object. For example:
 
 ```js
-import { default as __ui_components_my_app_component_ts__ } from '../ui/components/my-app/component.ts';
-import { default as __ui_components_my_app_page_banner_component_ts__ } from '../ui/components/my-app/page-banner/component.ts';
-import { default as __ui_components_my_app_page_banner_template_hbs__ } from '../ui/components/my-app/page-banner/template.hbs';
-import { default as __ui_components_my_app_page_banner_titleize_ts__ } from '../ui/components/my-app/page-banner/titleize.ts';
-import { default as __ui_components_my_app_template_hbs__ } from '../ui/components/my-app/template.hbs';
-import { default as __ui_components_text_editor_hbs__ } from '../ui/components/text-editor.hbs';
-import { default as __ui_components_text_editor_ts__ } from '../ui/components/text-editor.ts';
-export default {'component:/my-app/components/my-app': __ui_components_my_app_component_ts__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component_ts__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template_hbs__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize_ts__,'template:/my-app/components/my-app': __ui_components_my_app_template_hbs__,'template:/my-app/components/text-editor': __ui_components_text_editor_hbs__,'component:/my-app/components/text-editor': __ui_components_text_editor_ts__};
+import { default as __ui_components_my_app_component__ } from '../ui/components/my-app/component';
+import { default as __ui_components_my_app_page_banner_component__ } from '../ui/components/my-app/page-banner/component';
+import { default as __ui_components_my_app_page_banner_template__ } from '../ui/components/my-app/page-banner/template';
+import { default as __ui_components_my_app_page_banner_titleize__ } from '../ui/components/my-app/page-banner/titleize';
+import { default as __ui_components_my_app_template__ } from '../ui/components/my-app/template';
+export default {'component:/my-app/components/my-app': __ui_components_my_app_component__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize__,'template:/my-app/components/my-app': __ui_components_my_app_template__};
 ```
 
 ## Usage
@@ -164,7 +162,7 @@ let map = buildResolutionMap({
 });
 
 // returns {
-//   'component:/my-app/components/my-app': 'src/ui/components/my-app/component.ts'
+//   'component:/my-app/components/my-app': 'src/ui/components/my-app/component'
 // }
 ```
 

--- a/lib/build-resolution-map.js
+++ b/lib/build-resolution-map.js
@@ -75,8 +75,7 @@ module.exports = function(options) {
   mappedPaths.forEach(modulePath => {
     let pathParts = path.parse(modulePath);
     let module = path.posix.join(pathParts.dir, pathParts.name);
-    let extension = pathParts.ext;
-    let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module, extension);
+    let specifier = getModuleSpecifier(modulePrefix, moduleConfig, module);
 
     // Only process non-null specifiers returned.
     // Specifiers may be null in the case of an unresolvable collection (e.g. utils)

--- a/lib/build-resolution-map.js
+++ b/lib/build-resolution-map.js
@@ -25,8 +25,8 @@ const shouldIgnore = require('./should-ignore');
  * This function returns:
  * 
  *     {
- *       "component:/my-app/components/my-app": "ui/components/user-avatar/component.js",
- *       "template:/my-app/components/my-app": "ui/components/user-avatar/template.hbs"
+ *       "component:/my-app/components/my-app": "ui/components/user-avatar/component",
+ *       "template:/my-app/components/my-app": "ui/components/user-avatar/template"
  *     }
  * 
  * @param {object} options - configuration options for generating the map
@@ -64,7 +64,7 @@ module.exports = function(options) {
 
     // filter out index module
     if (name !== 'index' && name !== 'main') {
-      mappedPaths.push(modulePath);
+      mappedPaths.push(name);
     }
   });
 

--- a/lib/get-module-specifier.js
+++ b/lib/get-module-specifier.js
@@ -1,14 +1,8 @@
 'use strict';
 
-module.exports = function (modulePrefix, moduleConfig, modulePath, moduleExtension) {
+module.exports = function (modulePrefix, moduleConfig, modulePath) {
   let path;
   let collectionPath;
-
-  // TODO allow this setting in the resolver config
-  const defaultTypesByExtension = {
-    '.hbs': 'template',
-    '.handlebars': 'template'
-  };
 
   for (let i = 0, l = moduleConfig.collectionPaths.length; i < l; i++) {
     path = moduleConfig.collectionPaths[i];
@@ -62,9 +56,7 @@ module.exports = function (modulePrefix, moduleConfig, modulePath, moduleExtensi
     }
   } else {
     name = parts.pop();
-    if (defaultTypesByExtension[moduleExtension]) {
-      type = defaultTypesByExtension[moduleExtension];
-    } else if (collection.defaultType) {
+    if (collection.defaultType) {
       type = collection.defaultType;
     } else {
       throw new Error(`The type of module '${modulePath}' could not be identified`);

--- a/test/build-resolution-map-source-test.js
+++ b/test/build-resolution-map-source-test.js
@@ -32,9 +32,7 @@ describe('buildResolutionMapSource', function () {
                   "titleize.ts": ""
                 },
                 "template.hbs": ""
-              },
-              "text-editor.hbs": "",
-              "text-editor.ts": ""
+              }
             },
             "index.html": "<html>\n    <head></head>\n    <body></body>\n</html>\n"
           }
@@ -54,14 +52,12 @@ describe('buildResolutionMapSource', function () {
       modulePrefix: config.modulePrefix
     });
 
-    assert.strictEqual(source, `import { default as __ui_components_my_app_component_ts__ } from '../src/ui/components/my-app/component.ts';
-import { default as __ui_components_my_app_page_banner_component_ts__ } from '../src/ui/components/my-app/page-banner/component.ts';
-import { default as __ui_components_my_app_page_banner_template_hbs__ } from '../src/ui/components/my-app/page-banner/template.hbs';
-import { default as __ui_components_my_app_page_banner_titleize_ts__ } from '../src/ui/components/my-app/page-banner/titleize.ts';
-import { default as __ui_components_my_app_template_hbs__ } from '../src/ui/components/my-app/template.hbs';
-import { default as __ui_components_text_editor_hbs__ } from '../src/ui/components/text-editor.hbs';
-import { default as __ui_components_text_editor_ts__ } from '../src/ui/components/text-editor.ts';
-export default {'component:/my-app/components/my-app': __ui_components_my_app_component_ts__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component_ts__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template_hbs__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize_ts__,'template:/my-app/components/my-app': __ui_components_my_app_template_hbs__,'template:/my-app/components/text-editor': __ui_components_text_editor_hbs__,'component:/my-app/components/text-editor': __ui_components_text_editor_ts__};
+    assert.strictEqual(source, `import { default as __ui_components_my_app_component__ } from '../src/ui/components/my-app/component';
+import { default as __ui_components_my_app_page_banner_component__ } from '../src/ui/components/my-app/page-banner/component';
+import { default as __ui_components_my_app_page_banner_template__ } from '../src/ui/components/my-app/page-banner/template';
+import { default as __ui_components_my_app_page_banner_titleize__ } from '../src/ui/components/my-app/page-banner/titleize';
+import { default as __ui_components_my_app_template__ } from '../src/ui/components/my-app/template';
+export default {'component:/my-app/components/my-app': __ui_components_my_app_component__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize__,'template:/my-app/components/my-app': __ui_components_my_app_template__};
 `);
   });
 });

--- a/test/build-resolution-map-test.js
+++ b/test/build-resolution-map-test.js
@@ -32,9 +32,7 @@ describe('buildResolutionMap', function () {
                   "titleize.ts": ""
                 },
                 "template.hbs": ""
-              },
-              "text-editor.hbs": "",
-              "text-editor.ts": ""
+              }
             },
             "index.html": "<html>\n    <head></head>\n    <body></body>\n</html>\n"
           }
@@ -55,13 +53,11 @@ describe('buildResolutionMap', function () {
     });
 
     assert.deepEqual(map, {
-      'component:/my-app/components/my-app': 'ui/components/my-app/component.ts',
-      'component:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/component.ts',
-      'template:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/template.hbs',
-      'component:/my-app/components/my-app/page-banner/titleize': 'ui/components/my-app/page-banner/titleize.ts',
-      'template:/my-app/components/my-app': 'ui/components/my-app/template.hbs',
-      'template:/my-app/components/text-editor': 'ui/components/text-editor.hbs',
-      'component:/my-app/components/text-editor': 'ui/components/text-editor.ts'
+      'component:/my-app/components/my-app': 'ui/components/my-app/component',
+      'component:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/component',
+      'template:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/template',
+      'component:/my-app/components/my-app/page-banner/titleize': 'ui/components/my-app/page-banner/titleize',
+      'template:/my-app/components/my-app': 'ui/components/my-app/template',
     })
   });
 });

--- a/test/get-module-specifier-test.js
+++ b/test/get-module-specifier-test.js
@@ -51,90 +51,51 @@ describe('get-module-specifier', function() {
     moduleConfig = getModuleConfig(resolverConfig);
   });
 
-  it('identifies named modules in the root of a collection as the default type for that collection', function() {
-    let modulePath = 'ui/components/text-editor';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
-      'component:/my-app/components/text-editor'
-    );
-  });
-
-  it('identifies named modules in the root of a collection as the default type for their extension', function() {
-    let modulePath = 'ui/components/text-editor';
-    let moduleExtension = '.hbs';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
-      'template:/my-app/components/text-editor'
-    );
-  });
-
   it('identifies name/type modules in a collection', function() {
     let modulePath = 'ui/components/text-editor/component';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'component:/my-app/components/text-editor'
     );
   });
 
   it('identifies name/type modules with an extension that has a default type', function() {
     let modulePath = 'ui/components/text-editor/template';
-    let moduleExtension = '.hbs';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'template:/my-app/components/text-editor'
     );
   });
 
   it('identifies namespace/name/type modules in a collection', function() {
     let modulePath = 'ui/components/edit-form/text-editor/component';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'component:/my-app/components/edit-form/text-editor'
     );
   });
 
   it('identifies namespace/name modules as the default type for a collection', function() {
     let modulePath = 'ui/components/edit-form/text-editor';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'component:/my-app/components/edit-form/text-editor'
-    );
-  });
-
-  it('identifies namespace/name modules as the default type for their extension', function() {
-    let modulePath = 'ui/components/edit-form/text-editor';
-    let moduleExtension = '.hbs';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
-      'template:/my-app/components/edit-form/text-editor'
     );
   });
 
   it('identifies modules as the default type in private collections', function() {
     let modulePath = 'ui/routes/posts/-components/edit-form';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'component:/my-app/routes/posts/-components/edit-form'
-    );
-  });
-
-  it('identifies modules in private collections as the default type for their extension', function() {
-    let modulePath = 'ui/routes/posts/-components/edit-form';
-    let moduleExtension = '.hbs';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
-      'template:/my-app/routes/posts/-components/edit-form'
     );
   });
 
   it('identifies namespace/name/type modules in a private collection', function() {
     let modulePath = 'ui/routes/posts/-components/edit-form/text-editor/component';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       'component:/my-app/routes/posts/-components/edit-form/text-editor'
     );
   });
 
   it('returns null for modules in unresolvable collections', function() {
     let modulePath = 'ui/routes/posts/-utils/ignore-me';
-    let moduleExtension = '.js';
-    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath, moduleExtension),
+    assert.equal(getModuleSpecifier(modulePrefix, moduleConfig, modulePath),
       null
     );
   });

--- a/test/resolution-map-builder-test.js
+++ b/test/resolution-map-builder-test.js
@@ -40,9 +40,7 @@ describe('resolution-map-builder', function() {
                   "titleize.ts": ""
                 },
                 "template.hbs": ""
-              },
-              "text-editor.hbs": "",
-              "text-editor.ts": ""
+              }
             },
             "index.html": "<html>\n    <head></head>\n    <body></body>\n</html>\n"
           }
@@ -76,9 +74,6 @@ describe('resolution-map-builder', function() {
         'component:/my-app/components/my-app',
         'template:/my-app/components/my-app',
 
-        'component:/my-app/components/text-editor',
-        'template:/my-app/components/text-editor',
-
         'component:/my-app/components/my-app/page-banner',
         'template:/my-app/components/my-app/page-banner',
         'component:/my-app/components/my-app/page-banner/titleize'
@@ -98,9 +93,6 @@ describe('resolution-map-builder', function() {
       [
         'component:/my-app/components/my-app',
         'template:/my-app/components/my-app',
-
-        'component:/my-app/components/text-editor',
-        'template:/my-app/components/text-editor',
 
         'component:/my-app/components/my-app/page-banner',
         'template:/my-app/components/my-app/page-banner',
@@ -148,9 +140,6 @@ describe('resolution-map-builder', function() {
       [
         'component:/my-app/components/my-app',
         'template:/my-app/components/my-app',
-
-        'component:/my-app/components/text-editor',
-        'template:/my-app/components/text-editor',
 
         'component:/my-app/components/my-app/page-banner',
         'template:/my-app/components/my-app/page-banner',


### PR DESCRIPTION
This removes extensions from the resolution map. Extensions are not supportable because files with extensions like `.hbs` and `.ts` become unresolvable by the end of the build process.

Consequently, module paths like `src/ui/components/foo-bar.hbs` and `src/ui/components/foo-bar.js` become unsupportable, so this PR removes type inference by extension as it then becomes useless as far as I can tell.