### PR TITLE
fix: resolution map paths should be relative to project

### DIFF
--- a/lib/build-resolution-map-source.js
+++ b/lib/build-resolution-map-source.js
@@ -25,9 +25,7 @@ const getModuleIdentifier = require('./get-module-identifier');
 module.exports = function(options) {
   let resolutionMap = options.resolutionMap;
 
-  let srcDir = options.srcDir === undefined ? 'src' : options.srcDir;
   let configDir = options.configDir === undefined ? 'config' : options.configDir;
-  let configToSrcPath = path.posix.relative(configDir, srcDir);
 
   if (!resolutionMap) {
     resolutionMap = buildResolutionMap(options);
@@ -39,7 +37,7 @@ module.exports = function(options) {
 
   for (let specifier in resolutionMap) {
     let modulePath = resolutionMap[specifier];
-    let moduleImportPath = path.posix.join(configToSrcPath, modulePath);
+    let moduleImportPath = path.posix.relative(configDir, modulePath);
 
     let moduleVar = getModuleIdentifier(seenModuleVars, modulePath);
     let moduleImport = `import { default as ${moduleVar} } from '${moduleImportPath}';`;

--- a/lib/build-resolution-map.js
+++ b/lib/build-resolution-map.js
@@ -83,7 +83,8 @@ module.exports = function(options) {
       if (resolutionMap[specifier]) {
         throw new SilentError(`Both \`${resolutionMap[specifier]}\` and \`${modulePath}\` represent ${specifier}, please rename one to remove the collision.`);
       } else {
-        resolutionMap[specifier] = modulePath;
+        // Final module path should be relative to the project directory, not src dir.
+        resolutionMap[specifier] = path.posix.join(srcDir, modulePath);
       }
     }
   });

--- a/test/build-resolution-map-source-test.js
+++ b/test/build-resolution-map-source-test.js
@@ -52,12 +52,12 @@ describe('buildResolutionMapSource', function () {
       modulePrefix: config.modulePrefix
     });
 
-    assert.strictEqual(source, `import { default as __ui_components_my_app_component__ } from '../src/ui/components/my-app/component';
-import { default as __ui_components_my_app_page_banner_component__ } from '../src/ui/components/my-app/page-banner/component';
-import { default as __ui_components_my_app_page_banner_template__ } from '../src/ui/components/my-app/page-banner/template';
-import { default as __ui_components_my_app_page_banner_titleize__ } from '../src/ui/components/my-app/page-banner/titleize';
-import { default as __ui_components_my_app_template__ } from '../src/ui/components/my-app/template';
-export default {'component:/my-app/components/my-app': __ui_components_my_app_component__,'component:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_component__,'template:/my-app/components/my-app/page-banner': __ui_components_my_app_page_banner_template__,'component:/my-app/components/my-app/page-banner/titleize': __ui_components_my_app_page_banner_titleize__,'template:/my-app/components/my-app': __ui_components_my_app_template__};
+    assert.strictEqual(source, `import { default as __src_ui_components_my_app_component__ } from '../src/ui/components/my-app/component';
+import { default as __src_ui_components_my_app_page_banner_component__ } from '../src/ui/components/my-app/page-banner/component';
+import { default as __src_ui_components_my_app_page_banner_template__ } from '../src/ui/components/my-app/page-banner/template';
+import { default as __src_ui_components_my_app_page_banner_titleize__ } from '../src/ui/components/my-app/page-banner/titleize';
+import { default as __src_ui_components_my_app_template__ } from '../src/ui/components/my-app/template';
+export default {'component:/my-app/components/my-app': __src_ui_components_my_app_component__,'component:/my-app/components/my-app/page-banner': __src_ui_components_my_app_page_banner_component__,'template:/my-app/components/my-app/page-banner': __src_ui_components_my_app_page_banner_template__,'component:/my-app/components/my-app/page-banner/titleize': __src_ui_components_my_app_page_banner_titleize__,'template:/my-app/components/my-app': __src_ui_components_my_app_template__};
 `);
   });
 });

--- a/test/build-resolution-map-test.js
+++ b/test/build-resolution-map-test.js
@@ -53,11 +53,11 @@ describe('buildResolutionMap', function () {
     });
 
     assert.deepEqual(map, {
-      'component:/my-app/components/my-app': 'ui/components/my-app/component',
-      'component:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/component',
-      'template:/my-app/components/my-app/page-banner': 'ui/components/my-app/page-banner/template',
-      'component:/my-app/components/my-app/page-banner/titleize': 'ui/components/my-app/page-banner/titleize',
-      'template:/my-app/components/my-app': 'ui/components/my-app/template',
+      'component:/my-app/components/my-app': 'src/ui/components/my-app/component',
+      'component:/my-app/components/my-app/page-banner': 'src/ui/components/my-app/page-banner/component',
+      'template:/my-app/components/my-app/page-banner': 'src/ui/components/my-app/page-banner/template',
+      'component:/my-app/components/my-app/page-banner/titleize': 'src/ui/components/my-app/page-banner/titleize',
+      'template:/my-app/components/my-app': 'src/ui/components/my-app/template',
     })
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: This commit changes paths in resolution map *objects* (produced via the `buildResolutionMap()` function) to be relative to the project, not the src directory. It does not change the final generated source code, so does not impact existing Glimmer.js applications. Anyone using this functionality today is hardcoding `src` before paths, so resolving the compatibility change just means using the path as-is and discontinuing hardcoding `src`.

The intent of the resolution map object is, ultimately, to generate JavaScript code that imports modules and maps them on to Module Unification specifiers. While this system currently only supports addressing app modules via Module Unification, the intent has always been to make multiple packages addressable. For example, addons may want to contribute modules to the app's resolution map. In that case, the resolution map might look something like:

```js
import __my_component__ from '../node_modules/my-component/src/ui/components/MyComponent';

export default {
  "component:/my-component/components/MyComponent": __my_component__
};
```

While the paths generated by `buildResolutionMapSource()` are correctly relative to the app's `config` directory, the data structed by emitted `buildResolutionMap()` contains paths that are relative to the `src` directory—thus the system is hardcoded to only support files that originate in `src`.

This commit makes two changes:

1. Paths in the resolution map object are guaranteed to be relative to the project directory, not `src`. This means we can support other directories in the future, such as `lib/`, `node_modules/`, etc.
2. The source code generator calculates relative paths from `config/` to the provided path and does not hardcode `src/`.